### PR TITLE
Fix: 번역 flow

### DIFF
--- a/src/main/java/com/everybuddy/domain/media/entity/Media.java
+++ b/src/main/java/com/everybuddy/domain/media/entity/Media.java
@@ -48,6 +48,24 @@ public class Media {
     @Column(nullable = false)
     private MediaType mediaType;
 
+    // ── 번역 캐시 필드 (AUDIO·VIDEO 전용, 나머지 타입은 null) ──────────────────
+    @Enumerated(EnumType.STRING)
+    @Column(name = "translation_status")
+    private TranslationStatus translationStatus;
+
+    /** 첫 번역 요청자의 주 언어 코드 (예: "ko", "en") */
+    @Column(name = "target_language", length = 10)
+    private String targetLanguage;
+
+    /** 번역 결과 텍스트 */
+    @Column(name = "translated_text", columnDefinition = "TEXT")
+    private String translatedText;
+
+    /** 영상 세그먼트 JSON (VIDEO 전용, AUDIO는 null) */
+    @Column(name = "segments_json", columnDefinition = "MEDIUMTEXT")
+    private String segmentsJson;
+    // ─────────────────────────────────────────────────────────────────────────
+
     private LocalDateTime deletedAt;
 
     @CreatedDate
@@ -103,6 +121,32 @@ public class Media {
     public boolean isDeleted(){
         return this.deletedAt != null;
     }
+
+    // ── 번역 상태 전이 메서드 ────────────────────────────────────────────────
+
+    /** AUDIO·VIDEO 타입이어서 번역 캐싱 대상인지 확인 */
+    public boolean isTranslatable() {
+        return mediaType == MediaType.AUDIO || mediaType == MediaType.VIDEO;
+    }
+
+    /** 번역 요청 접수 — 첫 요청자의 주 언어를 기록하고 PENDING으로 전이 */
+    public void markTranslationPending(String targetLanguage) {
+        this.translationStatus = TranslationStatus.PENDING;
+        this.targetLanguage    = targetLanguage;
+    }
+
+    /** 번역 성공 — 결과 저장 후 COMPLETED 전이 */
+    public void completeTranslation(String translatedText, String segmentsJson) {
+        this.translationStatus = TranslationStatus.COMPLETED;
+        this.translatedText    = translatedText;
+        this.segmentsJson      = segmentsJson;
+    }
+
+    /** 번역 실패 — FAILED 전이 (다음 요청 시 재시도 가능) */
+    public void failTranslation() {
+        this.translationStatus = TranslationStatus.FAILED;
+    }
+    // ─────────────────────────────────────────────────────────────────────────
 
     /**
      * 테스트용 정적 팩토리 메서드

--- a/src/main/java/com/everybuddy/domain/media/entity/TranslationStatus.java
+++ b/src/main/java/com/everybuddy/domain/media/entity/TranslationStatus.java
@@ -1,0 +1,7 @@
+package com.everybuddy.domain.media.entity;
+
+public enum TranslationStatus {
+    PENDING,    // 번역 요청 후 처리 중
+    COMPLETED,  // 번역 완료 (DB 캐시 유효)
+    FAILED      // 번역 실패 (재시도 가능)
+}

--- a/src/main/java/com/everybuddy/domain/message/controller/MessageTranslationController.java
+++ b/src/main/java/com/everybuddy/domain/message/controller/MessageTranslationController.java
@@ -1,0 +1,70 @@
+package com.everybuddy.domain.message.controller;
+
+import com.everybuddy.domain.message.dto.TranslationResultResponse;
+import com.everybuddy.domain.message.service.MessageTranslationService;
+import com.everybuddy.global.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/messages")
+@RequiredArgsConstructor
+public class MessageTranslationController {
+
+    private final MessageTranslationService translationService;
+
+    /**
+     * 번역 요청 (첫 번째 클릭 → 비동기 시작, 이미 완료 → 즉시 결과 반환).
+     *
+     * <pre>
+     * 200 OK       → status="COMPLETED" (이미 번역된 캐시 존재)
+     * 202 Accepted → status="PENDING"   (번역 시작 또는 처리 중)
+     * 400          → 번역 불가 미디어 타입
+     * 403          → 채팅방 미참여
+     * 404          → 메시지 없음 / 삭제된 메시지
+     * </pre>
+     */
+    @PostMapping("/{messageId}/translate")
+    public ResponseEntity<TranslationResultResponse> requestTranslation(
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        TranslationResultResponse response =
+                translationService.requestTranslation(messageId, userDetails.getUserId());
+
+        HttpStatus status = "COMPLETED".equals(response.getStatus())
+                ? HttpStatus.OK
+                : HttpStatus.ACCEPTED;
+
+        return ResponseEntity.status(status).body(response);
+    }
+
+    /**
+     * 번역 결과 조회 (폴링 또는 Firebase 알림 수신 후 1회 호출).
+     *
+     * <pre>
+     * 200 OK       → status="COMPLETED" (번역 데이터 포함)
+     * 202 Accepted → status="PENDING"   (아직 처리 중)
+     * 400          → 번역 불가 미디어 타입
+     * 403          → 채팅방 미참여
+     * 404          → 아직 번역 요청 안 됨 / 메시지 없음
+     * </pre>
+     */
+    @GetMapping("/{messageId}/translation")
+    public ResponseEntity<TranslationResultResponse> getTranslation(
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        TranslationResultResponse response =
+                translationService.getTranslation(messageId, userDetails.getUserId());
+
+        HttpStatus status = "COMPLETED".equals(response.getStatus())
+                ? HttpStatus.OK
+                : HttpStatus.ACCEPTED;
+
+        return ResponseEntity.status(status).body(response);
+    }
+}

--- a/src/main/java/com/everybuddy/domain/message/dto/MessageResponse.java
+++ b/src/main/java/com/everybuddy/domain/message/dto/MessageResponse.java
@@ -32,10 +32,15 @@ public class MessageResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String mediaType;
 
+    /** PENDING|COMPLETED|FAILED — AUDIO·VIDEO 메시지에서만 존재 (null = 아직 번역 미요청) */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String translationStatus;
+
     @Builder
     private MessageResponse(Long messageId, Long userId, String userName, String messageType,
                             String content, String statusPreview, LocalDateTime sendAt, LocalDateTime editedAt,
-                            String fileUrl, String fileName, Long fileSize, String mediaType) {
+                            String fileUrl, String fileName, Long fileSize, String mediaType,
+                            String translationStatus) {
         this.messageId = messageId;
         this.userId = userId;
         this.userName = userName;
@@ -48,6 +53,7 @@ public class MessageResponse {
         this.fileName = fileName;
         this.fileSize = fileSize;
         this.mediaType = mediaType;
+        this.translationStatus = translationStatus;
     }
 
     private static final String DELETED_USER_NAME = "삭제된 유저";
@@ -64,10 +70,16 @@ public class MessageResponse {
                 .editedAt(message.getUpdatedAt());
 
         if (message.getMessageType() == MessageType.FILE && message.getMedia() != null) {
+            var media = message.getMedia();
             builder.fileUrl(fileUrl)
-                    .fileName(message.getMedia().getOriginalFilename())
-                    .fileSize(message.getMedia().getFileSize())
-                    .mediaType(message.getMedia().getMediaType().name());
+                    .fileName(media.getOriginalFilename())
+                    .fileSize(media.getFileSize())
+                    .mediaType(media.getMediaType().name());
+
+            // AUDIO·VIDEO 번역 상태 포함 (null이면 @JsonInclude(NON_NULL)로 응답에서 제외)
+            if (media.getTranslationStatus() != null) {
+                builder.translationStatus(media.getTranslationStatus().name());
+            }
         }
 
         return builder.build();

--- a/src/main/java/com/everybuddy/domain/message/dto/TranslationResultResponse.java
+++ b/src/main/java/com/everybuddy/domain/message/dto/TranslationResultResponse.java
@@ -1,0 +1,72 @@
+package com.everybuddy.domain.message.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * POST /api/v1/messages/{messageId}/translate
+ * GET  /api/v1/messages/{messageId}/translation 공통 응답 DTO.
+ *
+ * status = "PENDING"   → translatedText·segments null
+ * status = "COMPLETED" → translatedText 존재, segments는 VIDEO일 때만 존재
+ * status = "FAILED"    → translatedText·segments null
+ */
+@Getter
+@Builder
+public class TranslationResultResponse {
+
+    /** PENDING | COMPLETED | FAILED */
+    private final String status;
+
+    /** 번역 대상 언어 코드 (예: "ko") — COMPLETED 일 때만 존재 */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String targetLanguage;
+
+    /** 번역된 텍스트 전문 — COMPLETED 일 때만 존재 */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String translatedText;
+
+    /** 영상 구간별 번역 목록 — VIDEO + COMPLETED 일 때만 존재 */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final List<Segment> segments;
+
+    // ── 정적 팩토리 ─────────────────────────────────────────────────────────
+
+    public static TranslationResultResponse pending() {
+        return TranslationResultResponse.builder().status("PENDING").build();
+    }
+
+    public static TranslationResultResponse failed() {
+        return TranslationResultResponse.builder().status("FAILED").build();
+    }
+
+    public static TranslationResultResponse completed(String targetLanguage,
+                                                      String translatedText,
+                                                      List<Segment> segments) {
+        return TranslationResultResponse.builder()
+                .status("COMPLETED")
+                .targetLanguage(targetLanguage)
+                .translatedText(translatedText)
+                .segments(segments)
+                .build();
+    }
+
+    // ── 세그먼트 (VIDEO 전용) ────────────────────────────────────────────────
+
+    @Getter
+    @AllArgsConstructor
+    public static class Segment {
+        private final int    index;
+        private final double startSeconds;
+        private final double endSeconds;
+        private final String timestamp;
+        private final String sourceText;
+        private final String sourceLanguage;
+        private final String translatedText;
+        private final double inferenceSeconds;
+    }
+}

--- a/src/main/java/com/everybuddy/domain/message/event/TranslationRequestedEvent.java
+++ b/src/main/java/com/everybuddy/domain/message/event/TranslationRequestedEvent.java
@@ -1,0 +1,37 @@
+package com.everybuddy.domain.message.event;
+
+import com.everybuddy.domain.media.entity.Media;
+import com.everybuddy.domain.media.entity.MediaType;
+import com.everybuddy.domain.message.entity.Message;
+import lombok.Getter;
+
+/**
+ * 번역 요청이 처음 접수될 때(PENDING 전이 직후) 발행되는 이벤트.
+ * ChatRtdbEventHandler → Firebase PENDING 업데이트
+ * MessageTranslationAsyncService → 비동기 Triton 호출 시작
+ */
+@Getter
+public class TranslationRequestedEvent {
+
+    private final Long messageId;
+    private final Long chatRoomId;
+    private final Long mediaId;
+    private final MediaType mediaType;
+
+    private TranslationRequestedEvent(Long messageId, Long chatRoomId,
+                                      Long mediaId, MediaType mediaType) {
+        this.messageId  = messageId;
+        this.chatRoomId = chatRoomId;
+        this.mediaId    = mediaId;
+        this.mediaType  = mediaType;
+    }
+
+    public static TranslationRequestedEvent of(Message message, Media media) {
+        return new TranslationRequestedEvent(
+                message.getMessageId(),
+                message.getChatRoom().getChatRoomId(),
+                media.getMediaId(),
+                media.getMediaType()
+        );
+    }
+}

--- a/src/main/java/com/everybuddy/domain/message/event/TranslationStatusChangedEvent.java
+++ b/src/main/java/com/everybuddy/domain/message/event/TranslationStatusChangedEvent.java
@@ -1,0 +1,26 @@
+package com.everybuddy.domain.message.event;
+
+import com.everybuddy.domain.media.entity.TranslationStatus;
+import lombok.Getter;
+
+/**
+ * 비동기 번역이 완료(COMPLETED) 또는 실패(FAILED)로 전이될 때 발행되는 이벤트.
+ * ChatRtdbEventHandler → Firebase 상태 업데이트
+ */
+@Getter
+public class TranslationStatusChangedEvent {
+
+    private final Long messageId;
+    private final Long chatRoomId;
+    private final TranslationStatus status;
+
+    private TranslationStatusChangedEvent(Long messageId, Long chatRoomId, TranslationStatus status) {
+        this.messageId  = messageId;
+        this.chatRoomId = chatRoomId;
+        this.status     = status;
+    }
+
+    public static TranslationStatusChangedEvent of(Long messageId, Long chatRoomId, TranslationStatus status) {
+        return new TranslationStatusChangedEvent(messageId, chatRoomId, status);
+    }
+}

--- a/src/main/java/com/everybuddy/domain/message/service/MessageTranslationAsyncService.java
+++ b/src/main/java/com/everybuddy/domain/message/service/MessageTranslationAsyncService.java
@@ -1,0 +1,139 @@
+package com.everybuddy.domain.message.service;
+
+import com.everybuddy.domain.media.entity.Media;
+import com.everybuddy.domain.media.entity.MediaType;
+import com.everybuddy.domain.media.entity.TranslationStatus;
+import com.everybuddy.domain.media.repository.MediaRepository;
+import com.everybuddy.domain.message.event.TranslationRequestedEvent;
+import com.everybuddy.domain.message.event.TranslationStatusChangedEvent;
+import com.everybuddy.domain.translate.client.TritonClient;
+import com.everybuddy.global.exception.CustomException;
+import com.everybuddy.global.s3.service.StorageService;
+import com.everybuddy.global.util.FfmpegMediaConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 음성·영상 메시지 비동기 번역 처리 서비스.
+ *
+ * <pre>
+ * 흐름:
+ * 1. MessageTranslationService가 PENDING 전이 후 TranslationRequestedEvent 발행
+ * 2. 본 클래스의 handleTranslationRequested()가 커밋 후(@AFTER_COMMIT) 별도 스레드에서 실행
+ * 3. S3 다운로드 → (영상이면 ffmpeg 변환) → Triton 호출 → DB COMPLETED/FAILED 전이
+ * 4. TranslationStatusChangedEvent 발행 → ChatRtdbEventHandler가 Firebase 업데이트
+ * </pre>
+ *
+ * DB 연결을 Triton 대기 시간(최대 120s) 동안 점유하지 않도록
+ * S3 다운로드·Triton 호출 구간에서는 트랜잭션을 닫고 별도 {@code @Transactional} 로
+ * DB를 업데이트합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MessageTranslationAsyncService {
+
+    private final MediaRepository          mediaRepository;
+    private final StorageService           storageService;
+    private final TritonClient             tritonClient;
+    private final FfmpegMediaConverter     ffmpegConverter;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async("translationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTranslationRequested(TranslationRequestedEvent event) {
+        Long mediaId    = event.getMediaId();
+        Long messageId  = event.getMessageId();
+        Long chatRoomId = event.getChatRoomId();
+        MediaType mediaType = event.getMediaType();
+
+        log.info("[번역] 시작 messageId={} mediaId={} mediaType={}", messageId, mediaId, mediaType);
+
+        // ── Step 1. 미디어 정보 조회 (짧은 트랜잭션) ───────────────────────
+        MediaSnapshot snapshot = loadSnapshot(mediaId);
+        if (snapshot == null) {
+            log.warn("[번역] media를 찾을 수 없어 중단 mediaId={}", mediaId);
+            return;
+        }
+
+        // ── Step 2. S3 다운로드 (트랜잭션 외부) ────────────────────────────
+        byte[] fileBytes;
+        try {
+            fileBytes = storageService.downloadFile(snapshot.fileKey());
+        } catch (Exception e) {
+            log.error("[번역] S3 다운로드 실패 mediaId={}", mediaId, e);
+            saveFailedAndNotify(mediaId, messageId, chatRoomId);
+            return;
+        }
+
+        // ── Step 3. Triton 추론 (트랜잭션 외부, 최대 120s) ─────────────────
+        String translatedText;
+        String segmentsJson = null;
+        try {
+            if (mediaType == MediaType.VIDEO) {
+                byte[] wavBytes = ffmpegConverter.convertVideoToWav(fileBytes);
+                TritonClient.VideoTranslationResult result =
+                        tritonClient.translateVideoSpeech(wavBytes, snapshot.targetLanguage());
+                translatedText = result.translatedText();
+                segmentsJson   = result.segmentsJson();
+            } else {
+                // AUDIO
+                TritonClient.SpeechTranslationResult result =
+                        tritonClient.translateSpeech(fileBytes, snapshot.targetLanguage());
+                translatedText = result.translatedText();
+            }
+        } catch (CustomException e) {
+            log.error("[번역] Triton 오류 mediaId={} code={}", mediaId, e.getErrorCode(), e);
+            saveFailedAndNotify(mediaId, messageId, chatRoomId);
+            return;
+        } catch (Exception e) {
+            log.error("[번역] 예기치 못한 오류 mediaId={}", mediaId, e);
+            saveFailedAndNotify(mediaId, messageId, chatRoomId);
+            return;
+        }
+
+        // ── Step 4. 결과 저장 및 COMPLETED 이벤트 발행 ─────────────────────
+        saveCompletedAndNotify(mediaId, messageId, chatRoomId, translatedText, segmentsJson);
+        log.info("[번역] 완료 messageId={} mediaId={}", messageId, mediaId);
+    }
+
+    // ── 짧은 트랜잭션으로 미디어 정보 조회 ─────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    public MediaSnapshot loadSnapshot(Long mediaId) {
+        return mediaRepository.findById(mediaId)
+                .map(m -> new MediaSnapshot(m.getFileKey(), m.getTargetLanguage(), m.getMediaType()))
+                .orElse(null);
+    }
+
+    // ── COMPLETED 저장 + 이벤트 발행 ────────────────────────────────────────
+
+    @Transactional
+    public void saveCompletedAndNotify(Long mediaId, Long messageId, Long chatRoomId,
+                                       String translatedText, String segmentsJson) {
+        mediaRepository.findById(mediaId).ifPresent(media -> {
+            media.completeTranslation(translatedText, segmentsJson);
+        });
+        eventPublisher.publishEvent(
+                TranslationStatusChangedEvent.of(messageId, chatRoomId, TranslationStatus.COMPLETED));
+    }
+
+    // ── FAILED 저장 + 이벤트 발행 ───────────────────────────────────────────
+
+    @Transactional
+    public void saveFailedAndNotify(Long mediaId, Long messageId, Long chatRoomId) {
+        mediaRepository.findById(mediaId).ifPresent(Media::failTranslation);
+        eventPublisher.publishEvent(
+                TranslationStatusChangedEvent.of(messageId, chatRoomId, TranslationStatus.FAILED));
+    }
+
+    // ── 스냅샷 레코드 ────────────────────────────────────────────────────────
+
+    public record MediaSnapshot(String fileKey, String targetLanguage, MediaType mediaType) {}
+}

--- a/src/main/java/com/everybuddy/domain/message/service/MessageTranslationService.java
+++ b/src/main/java/com/everybuddy/domain/message/service/MessageTranslationService.java
@@ -1,0 +1,170 @@
+package com.everybuddy.domain.message.service;
+
+import com.everybuddy.domain.chatpart.repository.ChatPartRepository;
+import com.everybuddy.domain.media.entity.Media;
+import com.everybuddy.domain.media.entity.TranslationStatus;
+import com.everybuddy.domain.message.dto.TranslationResultResponse;
+import com.everybuddy.domain.message.dto.TranslationResultResponse.Segment;
+import com.everybuddy.domain.message.entity.Message;
+import com.everybuddy.domain.message.event.TranslationRequestedEvent;
+import com.everybuddy.domain.message.repository.MessageRepository;
+import com.everybuddy.domain.user.entity.UserLanguage;
+import com.everybuddy.domain.user.repository.UserLanguageRepository;
+import com.everybuddy.global.exception.CustomException;
+import com.everybuddy.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageTranslationService {
+
+    private static final ObjectMapper SEGMENT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private final MessageRepository        messageRepository;
+    private final ChatPartRepository       chatPartRepository;
+    private final UserLanguageRepository   userLanguageRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 번역 요청 (POST /api/v1/messages/{messageId}/translate).
+     *
+     * <ul>
+     *   <li>COMPLETED → 즉시 캐시 반환 (200)</li>
+     *   <li>PENDING   → 처리 중 안내 (202)</li>
+     *   <li>null·FAILED → PENDING 전이 후 비동기 Triton 호출 트리거 (202)</li>
+     * </ul>
+     */
+    @Transactional
+    public TranslationResultResponse requestTranslation(Long messageId, Long userId) {
+        Message message = findMessage(messageId);
+        validateChatParticipation(userId, message);
+
+        Media media = message.getMedia();
+        if (media == null || !media.isTranslatable()) {
+            throw new CustomException(ErrorCode.MEDIA_NOT_TRANSLATABLE);
+        }
+
+        // ── 이미 완료된 경우: 캐시 즉시 반환 ─────────────────────────────────
+        if (media.getTranslationStatus() == TranslationStatus.COMPLETED) {
+            return buildCompletedResponse(media);
+        }
+
+        // ── 이미 PENDING: 다른 사용자가 먼저 요청함 ──────────────────────────
+        if (media.getTranslationStatus() == TranslationStatus.PENDING) {
+            return TranslationResultResponse.pending();
+        }
+
+        // ── null or FAILED: 새 번역 요청 시작 ────────────────────────────────
+        String targetLanguage = resolvePrimaryLanguageCode(userId);
+        media.markTranslationPending(targetLanguage);
+        // @TransactionalEventListener(AFTER_COMMIT) 리스너가 커밋 후 Firebase·Triton 처리
+        eventPublisher.publishEvent(TranslationRequestedEvent.of(message, media));
+
+        return TranslationResultResponse.pending();
+    }
+
+    /**
+     * 번역 결과 조회 (GET /api/v1/messages/{messageId}/translation).
+     * PENDING이면 202, COMPLETED이면 200, 아직 요청 안 했으면 404.
+     */
+    @Transactional(readOnly = true)
+    public TranslationResultResponse getTranslation(Long messageId, Long userId) {
+        Message message = findMessage(messageId);
+        validateChatParticipation(userId, message);
+
+        Media media = message.getMedia();
+        if (media == null || !media.isTranslatable()) {
+            throw new CustomException(ErrorCode.MEDIA_NOT_TRANSLATABLE);
+        }
+
+        TranslationStatus status = media.getTranslationStatus();
+        if (status == null) {
+            throw new CustomException(ErrorCode.TRANSLATION_NOT_STARTED);
+        }
+
+        return switch (status) {
+            case COMPLETED -> buildCompletedResponse(media);
+            case PENDING   -> TranslationResultResponse.pending();
+            case FAILED    -> TranslationResultResponse.failed();
+        };
+    }
+
+    // ── 내부 유틸 ─────────────────────────────────────────────────────────────
+
+    private Message findMessage(Long messageId) {
+        return messageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MESSAGE_NOT_FOUND));
+    }
+
+    private void validateChatParticipation(Long userId, Message message) {
+        if (message.isDeleted()) {
+            throw new CustomException(ErrorCode.MESSAGE_ALREADY_DELETED);
+        }
+        Long chatRoomId = message.getChatRoom().getChatRoomId();
+        if (!chatPartRepository.existsByUserIdAndChatRoomId(userId, chatRoomId)) {
+            throw new CustomException(ErrorCode.USER_NOT_IN_CHATROOM);
+        }
+    }
+
+    private String resolvePrimaryLanguageCode(Long userId) {
+        UserLanguage primary = userLanguageRepository.findByUserUserIdAndIsPrimaryTrue(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_PRIMARY_LANGUAGE_NOT_FOUND));
+        return primary.getLanguage().getCode();
+    }
+
+    private TranslationResultResponse buildCompletedResponse(Media media) {
+        List<Segment> segments = parseSegments(media.getSegmentsJson());
+        return TranslationResultResponse.completed(
+                media.getTargetLanguage(),
+                media.getTranslatedText(),
+                segments
+        );
+    }
+
+    /** segmentsJson → Segment 리스트 변환 (VIDEO 전용, null이면 null 반환) */
+    private List<Segment> parseSegments(String segmentsJson) {
+        if (segmentsJson == null || segmentsJson.isBlank()) return null;
+        try {
+            SegmentsWrapper wrapper = SEGMENT_MAPPER.readValue(segmentsJson, SegmentsWrapper.class);
+            return wrapper.segments.stream()
+                    .map(s -> new Segment(
+                            s.index, s.startSeconds, s.endSeconds,
+                            s.timestamp, s.sourceText, s.sourceLanguage,
+                            s.translatedText, s.inferenceSeconds))
+                    .toList();
+        } catch (Exception e) {
+            return null; // 파싱 실패 시 세그먼트 없이 전문 텍스트만 반환
+        }
+    }
+
+    // ── SEGMENTS_JSON 파싱용 내부 클래스 ────────────────────────────────────
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class SegmentsWrapper {
+        List<SegmentItem> segments = List.of();
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class SegmentItem {
+        int    index;
+        double startSeconds;
+        double endSeconds;
+        String timestamp;
+        String sourceText;
+        String sourceLanguage;
+        String translatedText;
+        double inferenceSeconds;
+    }
+}

--- a/src/main/java/com/everybuddy/domain/translate/service/TranslateService.java
+++ b/src/main/java/com/everybuddy/domain/translate/service/TranslateService.java
@@ -11,23 +11,21 @@ import com.everybuddy.domain.user.entity.UserLanguage;
 import com.everybuddy.domain.user.repository.UserLanguageRepository;
 import com.everybuddy.global.exception.CustomException;
 import com.everybuddy.global.exception.ErrorCode;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.everybuddy.global.util.FfmpegMediaConverter;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -54,12 +52,9 @@ public class TranslateService {
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
 
-    // PATH 의존 없이 절대경로로 실행 (SonarQube S4036)
-    @Value("${ffmpeg.path}")
-    private String ffmpegPath;
-
     private final TritonClient tritonClient;
     private final UserLanguageRepository userLanguageRepository;
+    private final FfmpegMediaConverter ffmpegConverter;
 
     public TextTranslateResponse translateText(TextTranslateRequest request, Long userId) {
         String targetCode = resolvePrimaryLanguageCode(userId);
@@ -100,7 +95,7 @@ public class TranslateService {
             throw new CustomException(ErrorCode.MULTIPART_READ_FAILED, e);
         }
 
-        byte[] wavBytes = convertVideoToWav(videoBytes);
+        byte[] wavBytes = ffmpegConverter.convertVideoToWav(videoBytes);
         TritonClient.VideoTranslationResult result = tritonClient.translateVideoSpeech(wavBytes, targetCode);
 
         try {
@@ -148,47 +143,6 @@ public class TranslateService {
         String contentType = file.getContentType();
         if (contentType == null || !SUPPORTED_VIDEO_TYPES.contains(contentType.toLowerCase())) {
             throw new CustomException(ErrorCode.INVALID_VIDEO_FORMAT);
-        }
-    }
-
-    private byte[] convertVideoToWav(byte[] videoBytes) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder(
-                    ffmpegPath, "-i", "pipe:0",
-                    "-vn",                          // 비디오 스트림 명시적 제외
-                    "-ac", "1", "-ar", "16000",
-                    "-f", "wav", "-loglevel", "error",
-                    "pipe:1"
-            );
-            // stderr를 명시적으로 버려야 ffmpeg 오류 메시지가 버퍼를 채워 프로세스가 블로킹되는 상황을 방지
-            pb.redirectError(ProcessBuilder.Redirect.DISCARD);
-            Process process = pb.start();
-
-            // stdin 쓰기를 별도 스레드에서 처리 — stdout 읽기와 동시에 진행해야 데드락 방지
-            Thread stdinWriter = new Thread(() -> {
-                try (OutputStream stdin = process.getOutputStream()) {
-                    stdin.write(videoBytes);
-                } catch (IOException ignored) {}
-            }, "ffmpeg-stdin-writer");
-            stdinWriter.start();
-
-            byte[] wavBytes = process.getInputStream().readAllBytes();
-            boolean finished = process.waitFor(90, TimeUnit.SECONDS);
-            stdinWriter.join(5_000);
-
-            if (!finished || process.exitValue() != 0 || wavBytes.length == 0) {
-                process.destroyForcibly();
-                throw new CustomException(ErrorCode.VIDEO_CONVERT_FAILED);
-            }
-            return wavBytes;
-        } catch (CustomException e) {
-            throw e;
-        } catch (InterruptedException e) {
-            // 인터럽트 상태 복구 — 상위 레이어가 인터럽트를 인지할 수 있도록 보장
-            Thread.currentThread().interrupt();
-            throw new CustomException(ErrorCode.VIDEO_CONVERT_FAILED, e);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.VIDEO_CONVERT_FAILED, e);
         }
     }
 

--- a/src/main/java/com/everybuddy/global/config/AsyncConfig.java
+++ b/src/main/java/com/everybuddy/global/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.everybuddy.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /**
+     * 음성·영상 비동기 번역 전용 스레드 풀.
+     * Triton 추론은 최대 120초까지 걸릴 수 있으므로 일반 async 풀과 분리합니다.
+     */
+    @Bean("translationExecutor")
+    public Executor translationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("translation-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/everybuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/everybuddy/global/exception/ErrorCode.java
@@ -79,6 +79,9 @@ public enum ErrorCode {
     FIREBASE_INITIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서비스 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
 
     // 번역 관련
+    MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "미디어를 찾을 수 없습니다."),
+    MEDIA_NOT_TRANSLATABLE(HttpStatus.BAD_REQUEST, 400, "번역이 지원되지 않는 미디어 타입입니다. (오디오·영상만 가능)"),
+    TRANSLATION_NOT_STARTED(HttpStatus.NOT_FOUND, 404, "아직 번역이 요청되지 않은 메시지입니다."),
     UNSUPPORTED_LANGUAGE(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 언어 코드입니다."),
     USER_PRIMARY_LANGUAGE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 500, "사용자의 주 언어 정보를 찾을 수 없습니다."),
     INVALID_AUDIO_FORMAT(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 오디오 형식입니다."),

--- a/src/main/java/com/everybuddy/global/firebase/ChatRtdbEventHandler.java
+++ b/src/main/java/com/everybuddy/global/firebase/ChatRtdbEventHandler.java
@@ -12,6 +12,8 @@ import com.everybuddy.domain.message.event.MessageDeletedEvent;
 import com.everybuddy.domain.message.event.MessageReadEvent;
 import com.everybuddy.domain.message.event.MessageSentEvent;
 import com.everybuddy.domain.message.event.MessageUpdatedEvent;
+import com.everybuddy.domain.message.event.TranslationRequestedEvent;
+import com.everybuddy.domain.message.event.TranslationStatusChangedEvent;
 import com.everybuddy.global.s3.service.StorageService;
 import com.google.api.core.ApiFuture;
 import com.google.firebase.database.DatabaseReference;
@@ -63,6 +65,26 @@ public class ChatRtdbEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMessageUpdated(MessageUpdatedEvent event) {
         updateFirebaseAsEdited(event.getMessage());
+    }
+
+    /**
+     * 번역 PENDING 전이 → Firebase 상태 업데이트.
+     * MessageTranslationService가 PENDING 설정 후 커밋 시 호출됩니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTranslationRequested(TranslationRequestedEvent event) {
+        updateTranslationStatusInFirebase(
+                event.getChatRoomId(), event.getMessageId(), "PENDING");
+    }
+
+    /**
+     * 번역 COMPLETED·FAILED 전이 → Firebase 상태 업데이트.
+     * MessageTranslationAsyncService가 결과 저장 후 커밋 시 호출됩니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTranslationStatusChanged(TranslationStatusChangedEvent event) {
+        updateTranslationStatusInFirebase(
+                event.getChatRoomId(), event.getMessageId(), event.getStatus().name());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -207,6 +229,22 @@ public class ChatRtdbEventHandler {
 
     private static Object incrementBy(int delta) {
         return Map.of(".sv", Map.of("increment", delta));
+    }
+
+    /**
+     * Firebase messages/{chatRoomId}/{messageId}/translationStatus 필드 업데이트.
+     * 기존 메시지 노드의 단일 필드만 갱신하므로 다른 필드에 영향 없음.
+     */
+    private void updateTranslationStatusInFirebase(Long chatRoomId, Long messageId, String statusName) {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("translationStatus", statusName);
+        DatabaseReference ref = firebaseDatabase.getReference("messages")
+                .child(String.valueOf(chatRoomId))
+                .child(String.valueOf(messageId));
+        addFirebaseCallback(
+                ref.updateChildrenAsync(updates),
+                "번역 상태 업데이트 chatRoomId=" + chatRoomId + " messageId=" + messageId + " status=" + statusName
+        );
     }
 
     private void addFirebaseCallback(ApiFuture<Void> future, String context) {

--- a/src/main/java/com/everybuddy/global/s3/service/S3FileService.java
+++ b/src/main/java/com/everybuddy/global/s3/service/S3FileService.java
@@ -205,17 +205,11 @@ public class S3FileService implements StorageService {
     }
 
     /**
-     * 채팅 파일 검증 (이미지, 비디오, 오디오, 문서, 압축, 10MB)
+     * 채팅 파일 검증 (이미지·문서·압축 10MB / 오디오·영상 50MB)
      */
     private void validateChatFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.EMPTY_FILE);
-        }
-
-        // 파일 크기 검사 (10MB)
-        long maxSize = 10L * 1024 * 1024;
-        if (file.getSize() > maxSize) {
-            throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
 
         // 파일 이름 검증
@@ -224,17 +218,29 @@ public class S3FileService implements StorageService {
             throw new CustomException(ErrorCode.INVALID_FILE_NAME);
         }
 
+        // MIME 타입 검증 (확장자 조작 방지) — 크기 검사 전에 타입을 먼저 확인
+        String contentType = file.getContentType();
+        if (contentType == null || !isAllowedContentType(contentType)) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // 파일 크기 검사: 오디오·영상은 번역 기능을 위해 50MB, 나머지는 10MB
+        long maxSize = isAudioOrVideoContentType(contentType)
+                ? 50L * 1024 * 1024   // 오디오·영상
+                : 10L * 1024 * 1024;  // 이미지·문서·압축
+        if (file.getSize() > maxSize) {
+            throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
         // 파일 확장자 검증
         String extension = extractExtension(originalFilename);
         if (!isChatFileExtension(extension)) {
             throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
         }
+    }
 
-        // MIME 타입 검증 (확장자 조작 방지)
-        String contentType = file.getContentType();
-        if (contentType == null || !isAllowedContentType(contentType)) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
+    private boolean isAudioOrVideoContentType(String contentType) {
+        return contentType.startsWith("audio/") || contentType.startsWith("video/");
     }
 
     /**

--- a/src/main/java/com/everybuddy/global/s3/service/S3FileService.java
+++ b/src/main/java/com/everybuddy/global/s3/service/S3FileService.java
@@ -124,6 +124,22 @@ public class S3FileService implements StorageService {
     }
 
     /**
+     * 파일 바이트 다운로드 (비동기 번역 처리에 사용)
+     */
+    @Override
+    public byte[] downloadFile(String key) {
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+            return s3Client.getObjectAsBytes(getObjectRequest).asByteArray();
+        } catch (S3Exception | SdkClientException e) {
+            throw new CustomException(ErrorCode.S3_CONNECTION_ERROR);
+        }
+    }
+
+    /**
      * 파일 존재 여부 확인
      * @param key S3 객체 키
      * @return 존재 여부

--- a/src/main/java/com/everybuddy/global/s3/service/StorageService.java
+++ b/src/main/java/com/everybuddy/global/s3/service/StorageService.java
@@ -51,4 +51,11 @@ public interface StorageService {
      * @return 존재 여부
      */
     boolean fileExists(String fileKey);
+
+    /**
+     * 파일 바이트 다운로드 (비동기 번역 처리에 사용)
+     * @param fileKey 파일 키
+     * @return 파일 전체 바이트
+     */
+    byte[] downloadFile(String fileKey);
 }

--- a/src/main/java/com/everybuddy/global/util/FfmpegMediaConverter.java
+++ b/src/main/java/com/everybuddy/global/util/FfmpegMediaConverter.java
@@ -1,0 +1,73 @@
+package com.everybuddy.global.util;
+
+import com.everybuddy.global.exception.CustomException;
+import com.everybuddy.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ffmpeg를 사용한 미디어 변환 유틸리티.
+ * 절대 경로(@Value)를 사용해 PATH 의존성(SonarQube S4036) 을 제거합니다.
+ */
+@Component
+public class FfmpegMediaConverter {
+
+    private final String ffmpegPath;
+
+    public FfmpegMediaConverter(@Value("${ffmpeg.path}") String ffmpegPath) {
+        this.ffmpegPath = ffmpegPath;
+    }
+
+    /**
+     * 동영상 바이트를 Triton S2TT 모델용 WAV(mono 16kHz)로 변환합니다.
+     *
+     * @param videoBytes mp4·mov 원본 바이트
+     * @return PCM WAV 바이트
+     * @throws CustomException VIDEO_CONVERT_FAILED
+     */
+    public byte[] convertVideoToWav(byte[] videoBytes) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                    ffmpegPath, "-i", "pipe:0",
+                    "-vn",                          // 비디오 스트림 명시적 제외
+                    "-ac", "1", "-ar", "16000",
+                    "-f", "wav", "-loglevel", "error",
+                    "pipe:1"
+            );
+            // stderr를 버려 ffmpeg 오류 메시지가 버퍼를 채워 프로세스가 블로킹되는 상황을 방지
+            pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+            Process process = pb.start();
+
+            // stdin 쓰기를 별도 스레드에서 처리 — stdout 읽기와 동시에 진행해야 데드락 방지
+            Thread stdinWriter = new Thread(() -> {
+                try (OutputStream stdin = process.getOutputStream()) {
+                    stdin.write(videoBytes);
+                } catch (IOException ignored) {}
+            }, "ffmpeg-stdin-writer");
+            stdinWriter.start();
+
+            byte[] wavBytes = process.getInputStream().readAllBytes();
+            boolean finished = process.waitFor(90, TimeUnit.SECONDS);
+            stdinWriter.join(5_000);
+
+            if (!finished || process.exitValue() != 0 || wavBytes.length == 0) {
+                process.destroyForcibly();
+                throw new CustomException(ErrorCode.VIDEO_CONVERT_FAILED);
+            }
+            return wavBytes;
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (InterruptedException e) {
+            // 인터럽트 상태 복구 — 상위 레이어가 인터럽트를 인지할 수 있도록 보장
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.VIDEO_CONVERT_FAILED, e);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.VIDEO_CONVERT_FAILED, e);
+        }
+    }
+}


### PR DESCRIPTION
📝 변경 사항

<html>
<body>
<hr>
<h2>📋 프론트엔드 변경 API 명세</h2>
<h3>🔴 신규 API</h3>
<hr>
<h4><code>POST /api/v1/messages/{messageId}/translate</code></h4>
<p><strong>번역 요청</strong> — 번역 버튼 첫 클릭 시 호출</p>

항목 | 내용
-- | --
Auth | Bearer JWT 필수
조건 | 해당 채팅방 참여자만 가능, mediaType = AUDIO or VIDEO 메시지만


<hr>
<h3>🟡 기존 API 변경사항</h3>
<h4><code>GET /api/v1/messages/chatrooms/{chatRoomId}</code> — <code>MessageResponse</code> 필드 추가</h4>
<p>AUDIO·VIDEO 메시지에 <code>translationStatus</code> 필드가 추가됨 (재연결·동기화 시 상태 복원용)</p>
<pre><code class="language-jsonc">{
  "messageId": 123,
  "userId": 1,
  "messageType": "FILE",
  "mediaType": "AUDIO",
  "fileUrl": "https://...",
  "fileName": "voice.m4a",
  "fileSize": 204800,
  "translationStatus": "COMPLETED",   // ← NEW (null이면 필드 자체가 없음)
  "sendAt": "2025-05-26T10:00:00"
}
</code></pre>
<p><code>translationStatus</code> 값 의미:</p>
<ul>
<li><strong>필드 없음 (null)</strong> — 아직 아무도 번역 요청 안 함</li>
<li><code>"PENDING"</code> — 번역 처리 중</li>
<li><code>"COMPLETED"</code> — 번역 완료 (GET 조회 가능)</li>
<li><code>"FAILED"</code> — 번역 실패 (POST로 재시도 가능)</li>
</ul>
<hr>
<h3>🟡 Firebase Realtime DB 구조 변경</h3>
<h4>기존 메시지 노드 구조</h4>
<pre><code class="language-json">messages/{chatRoomId}/{messageId}: {
  "userId": 1,
  "messageType": "FILE",
  "mediaType": "AUDIO",
  "fileUrl": "...",
  "sendAt": 1716721200000
}
</code></pre>
<h4>변경 후 — <code>translationStatus</code> 필드 추가</h4>
<pre><code class="language-json">messages/{chatRoomId}/{messageId}: {
  "userId": 1,
  "messageType": "FILE",
  "mediaType": "AUDIO",
  "fileUrl": "...",
  "sendAt": 1716721200000,
  "translationStatus": "PENDING"   // ← NEW (초기 전송 시 없음, 번역 요청 후 추가)
}
</code></pre>
<p><strong>타임라인:</strong></p>
<pre><code>[메시지 전송]          → translationStatus 필드 없음
[번역 버튼 첫 클릭]    → translationStatus = "PENDING" 필드 추가
[번역 완료]            → translationStatus = "COMPLETED" 업데이트
[번역 실패]            → translationStatus = "FAILED"  업데이트
</code></pre>
<p><strong>프론트 리스너 처리 가이드:</strong></p>
<pre><code class="language-js">// Firebase 메시지 변경 감지
ref.on('child_changed', (snapshot) =&gt; {
  const msg = snapshot.val();
  const key = snapshot.key;  // messageId

  if (msg.translationStatus === 'COMPLETED') {
    // GET /api/v1/messages/{messageId}/translation 호출
    fetchTranslation(key);
  } else if (msg.translationStatus === 'PENDING') {
    // 로딩 UI 표시
    showTranslationLoading(key);
  } else if (msg.translationStatus === 'FAILED') {
    // 번역 실패 안내 + 재시도 버튼 활성화
    showTranslationFailed(key);
  }
});
</code></pre>
<hr>
<h3>📱 전체 번역 플로우 (프론트 기준)</h3>
<pre><code>[채팅 화면]
  ↓ AUDIO·VIDEO 메시지에만 "번역" 버튼 표시 (mediaType 기준)
  ↓
[번역 버튼 클릭]
  POST /api/v1/messages/{messageId}/translate
  ↓
  ├─ 200: 즉시 번역 결과 표시 (캐시 히트)
  └─ 202 PENDING: 로딩 스피너 표시
       ↓
       Firebase child_changed 수신 대기
       ↓
       translationStatus = "COMPLETED"
       ↓
       GET /api/v1/messages/{messageId}/translation
       ↓
       번역 결과 표시
</code></pre>
<hr>
<p>요약하면, 프론트에서 해야 할 변경은 크게 <strong>3가지</strong>:</p>
<ol>
<li><strong>번역 버튼 추가</strong> — <code>mediaType == "AUDIO" || "VIDEO"</code> 메시지에만 표시</li>
<li><strong>Firebase 리스너</strong> — <code>child_changed</code>에서 <code>translationStatus</code> 필드 감지 → <code>COMPLETED</code>이면 GET 호출</li>
<li><strong>재연결 처리</strong> — <code>GET /api/v1/messages/chatrooms/{chatRoomId}</code> 응답의 <code>translationStatus</code> 필드로 버튼 상태 복원</li>
</ol></body></html><!--EndFragment-->
</body>
</html>

🔍 관련 이슈  
이 PR이 해결하는 이슈: #105 

✅ 테스트 결과

- [ ] 기능 테스트 완료
- [ ] 버그 테스트 완료

📌 추가 사항

- <추가로 고려해야 할 사항>
